### PR TITLE
go back to text file open so that jason.load does not raise TypeError

### DIFF
--- a/hangouts_parser.py
+++ b/hangouts_parser.py
@@ -18,7 +18,7 @@ class HangoutsParser:
         """
         conversations = []
         self_gaia_id = None  # gaia_id for the phone owner
-        with open(hangouts_file_name, 'rb') as data_file:
+        with open(hangouts_file_name, 'r') as data_file:
             # Read the Hangouts JSON file and turn into objects
             data = json.load(data_file, object_hook=lambda d: Namespace(**d))
             # Iterate through each conversation in the list


### PR DESCRIPTION
TypeError exception 'TypeError: the JSON object must be str, not \'bytes\''

Resolves: https://github.com/adein/hangouts_to_sms/issues/2